### PR TITLE
Handling MongoDB connection error

### DIFF
--- a/src/karma_tracker/commands.clj
+++ b/src/karma_tracker/commands.clj
@@ -9,9 +9,9 @@
 (defmethod execute :default [_ command]
   (throw (ex-info "Command not implemented" {:command command})))
 
-(defmacro with-db [& fns]
+(defmacro with-db [& body]
   `(try
-     ~@fns
+     ~@body
      (catch com.mongodb.MongoTimeoutException e#
        [:error "Could not connect to MongoDB"])))
 

--- a/src/karma_tracker/commands.clj
+++ b/src/karma_tracker/commands.clj
@@ -9,9 +9,16 @@
 (defmethod execute :default [_ command]
   (throw (ex-info "Command not implemented" {:command command})))
 
+(defmacro with-db [& fns]
+  `(try
+     ~@fns
+     (catch com.mongodb.MongoTimeoutException e#
+       [:error "Could not connect to MongoDB"])))
+
 (defmethod execute :update [{:keys [github-conn events-storage]} _]
-  (update-events @github-conn @events-storage (env :organisation))
-  [:events-updated])
+  (with-db
+    (update-events @github-conn @events-storage (env :organisation))
+    [:events-updated]))
 
 (defmethod execute :report [{:keys [github-conn events-storage]} [_ year month]]
   [:report-generated year month])

--- a/test/karma_tracker/commands_test.clj
+++ b/test/karma_tracker/commands_test.clj
@@ -16,4 +16,9 @@
         (is (= [:events-updated]
                (execute fake-resources [:update])))
         (is (= [:gh :storage "redbadger"]
-               @update-events-result))))))
+               @update-events-result)))))
+  (testing "DB connection fails returns error"
+    (with-redefs [update-events (fn [& args]
+                                  (throw (com.mongodb.MongoTimeoutException. "")))]
+      (is (= [:error "Could not connect to MongoDB"]
+             (execute fake-resources [:update]))))))


### PR DESCRIPTION
Returns an error with a nice message rather than just falling over if the connection to MongoDB fails.