### PR TITLE
Data availability api

### DIFF
--- a/src/karma_tracker/api/core.clj
+++ b/src/karma_tracker/api/core.clj
@@ -1,7 +1,9 @@
 (ns karma-tracker.api.core
   (:require [compojure.core :refer :all]
             [karma-tracker.api.query :refer [query-routes]]
+            [karma-tracker.api.info :refer [info-routes]]
             [karma-tracker.query.core :as query]
+            [karma-tracker.info :as info]
             [ring.adapter.jetty :refer [run-jetty]]
             [ring.middleware
              [cors :refer [wrap-cors]]
@@ -17,11 +19,13 @@
 
 (defn api [execution-fns]
   (-> (routes
-       (query-routes (:query execution-fns)))
+       (query-routes (:query execution-fns))
+       (info-routes (:info execution-fns)))
       wrap-handler))
 
 (defn get-execution-fns [resources]
-  {:query (partial query/execute resources)})
+  {:query (partial query/execute resources)
+   :info  (partial info/retrieve resources)})
 
 (defn run-server [resources]
   (println "Api server running on port 8000")

--- a/src/karma_tracker/api/info.clj
+++ b/src/karma_tracker/api/info.clj
@@ -1,0 +1,36 @@
+(ns karma-tracker.api.info
+  (:require [compojure.core :refer :all]
+            [ring.util.response :refer :all]
+            [cheshire.core :refer [generate-string]]))
+
+(defn- default-headers [request]
+  (-> request
+      (content-type "application/json")
+      (header "Cache-Control" "max-age=86400; public")))
+
+(defn- info-response [info-request retrieve-info-fn]
+  (-> info-request
+      retrieve-info-fn
+      generate-string
+      response
+      default-headers))
+
+(defn- invalid-info-response [ex]
+  (-> ex
+      ex-data
+      (merge {:error (.getMessage ex)})
+      generate-string
+      response
+      default-headers
+      (status 400)))
+
+(defn- info-request-handler [retrieve-info-fn request]
+  (let [info-request (-> request :params :info-request keyword)]
+    (try
+      (info-response info-request retrieve-info-fn)
+      (catch RuntimeException ex
+        (invalid-info-response ex)))))
+
+(defn info-routes [retrieve-info-fn]
+  (routes
+   (GET "/api/info/:info-request" [] (partial info-request-handler retrieve-info-fn))))

--- a/src/karma_tracker/info.clj
+++ b/src/karma_tracker/info.clj
@@ -1,0 +1,12 @@
+(ns karma-tracker.info
+  (:require [karma-tracker.events-repository :refer [get-available-months]]))
+
+(defmulti retrieve
+  (fn [resources info-request]
+    info-request))
+
+(defmethod retrieve :available-months [{:keys [events-storage]} _]
+  (get-available-months @events-storage))
+
+(defmethod retrieve :default [_ info-request]
+  (throw (ex-info "Info request not valid" {:info-request info-request})))

--- a/src/karma_tracker/query/contributions.clj
+++ b/src/karma_tracker/query/contributions.clj
@@ -17,12 +17,20 @@
 (defn- activity-stats-inc [value]
   (if (nil? value) 1 (inc value)))
 
+(defn- normalise-comment-field [{issues :issue-comment prs :pull-request-review-comment
+                                 :or {issues 0 prs 0}
+                                 :as stats}]
+  (let [sum (+ issues prs)]
+    (if (> sum 0)
+      (assoc stats :comment sum)
+      stats)))
+
 (defn- normalise-stats [{issues :issue-comment prs :pull-request-review-comment
                          :or {issues 0 prs 0}
                          :as stats}]
   (-> stats
       (dissoc :push)
-      (assoc :comment (+ issues prs))
+      (normalise-comment-field)
       (dissoc :issue-comment :pull-request-review-comment)))
 
 (defn- activity-stats [events]

--- a/test/karma_tracker/api/info_test.clj
+++ b/test/karma_tracker/api/info_test.clj
@@ -1,0 +1,26 @@
+(ns karma-tracker.api.info-test
+  (:require [karma-tracker.api.info :refer :all]
+            [clojure.test :refer :all]
+            [karma-tracker.api
+             [core :refer [wrap-handler]]
+             [mock :refer [make-request]]]))
+
+(defn- request-handler [execution-fn]
+  (wrap-handler (info-routes execution-fn)))
+
+(deftest retrieve-not-valid-info-test
+  (let [request  (make-request :get "/api/info/not-valid-info")
+        handler  (request-handler (fn [_]
+                                    (throw (ex-info "Invalid request" {:info-request "not-valid-info"}))))
+        response (handler request)]
+    (is (= (:status response) 400))
+    (is (= (:body response) "{\"info-request\":\"not-valid-info\",\"error\":\"Invalid request\"}"))))
+
+(deftest retrieve-info-test
+  (let [request  (make-request :get "/api/info/a-valid-info")
+        handler  (request-handler (fn [request]
+                                    (let [{{:keys [info-request]} :params} request]
+                                      [:info 1 2 3 4])))
+        response (handler request)]
+    (is (= (:status response) 200))
+    (is (= (:body response) "[\"info\",1,2,3,4]"))))

--- a/test/karma_tracker/api/query_test.clj
+++ b/test/karma_tracker/api/query_test.clj
@@ -41,3 +41,11 @@
     (is (= @queries [{:source :users :interval query-interval}
                      {:source :contributions :interval query-interval}]))
     (is (= (:body response) "{\"contributions\":\"multiple fake query response\",\"users\":\"multiple fake query response\"}"))))
+
+(deftest no-events-response
+  (let [request            (make-request :get "/api/query/2017-01-01/2017-03-31/languages")
+        [queries response] (process-request request (constantly []))]
+    (is (= (:status response) 404))
+    (is (= (:body response) "[]"))
+    (is (= (:headers response) {"Content-Type"  "application/json",
+                                "Cache-Control" "max-age=86400; public"}))))

--- a/test/karma_tracker/events_repository_test.clj
+++ b/test/karma_tracker/events_repository_test.clj
@@ -57,3 +57,11 @@
 (deftest creates-index
   (let [index-keys (map :key (collection/indexes-on db events-collection))]
     (is (some #{{:created_at 1}} index-keys))))
+
+(deftest get-available-months-test
+  (add db [{:id 1, :created_at (date-time 2017 1)}
+           {:id 2, :created_at (date-time 2017 2)}
+           {:id 3, :created_at (date-time 2016 12)}
+           {:id 4, :created_at (date-time 2016 11)}])
+  (is (= (get-available-months db)
+         [[2016 11] [2016 12] [2017 1] [2017 2]])))

--- a/test/karma_tracker/info_test.clj
+++ b/test/karma_tracker/info_test.clj
@@ -1,0 +1,6 @@
+(ns karma-tracker.info-test
+  (:require [karma-tracker.info :refer :all]
+            [clojure.test :refer :all]))
+
+(deftest retrieve-request-invalid-test
+  (is (thrown? RuntimeException (retrieve nil :not-existing-info))))

--- a/test/karma_tracker/query/core_test.clj
+++ b/test/karma_tracker/query/core_test.clj
@@ -44,24 +44,20 @@
   (let [query (test-query :contributions)]
     (is (= '({:item :commit, :value 11, :percentage "84.6%"}
              {:item :issue, :value 1, :percentage "7.7%"}
-             {:item :pull-request, :value 1, :percentage "7.7%"}
-             {:item :comment, :value 0, :percentage "0.0%"})
+             {:item :pull-request, :value 1, :percentage "7.7%"})
            (execute (get-resources) query)))))
 
 (deftest execute-repos-contributions-query-test
   (let [query (test-query :repos-contributions)]
     (is (= '({:commit 11,
-              :comment 0,
               :repo "redbadger/blog-squarespace-template",
               :total 11,
               :percentage "84.6%"}
              {:issue 1,
-              :comment 0,
               :repo "facebook/react",
               :total 1,
               :percentage "7.7%"}
              {:pull-request 1,
-              :comment 0,
               :repo "facebook/react-devtools",
               :total 1,
               :percentage "7.7%"})


### PR DESCRIPTION
The API returns http status 404 when there are no events for the specified interval.
This should make easier for the UI to understand when there is no data available for the selected month.